### PR TITLE
Changed property spelling

### DIFF
--- a/dist/assets/jd-table.scss
+++ b/dist/assets/jd-table.scss
@@ -1684,7 +1684,7 @@
 	sub,
 	sup
 	{
-		ont-size: 75%;
+		font-size: 75%;
 		line-height: 0;
 		position: relative;
 		vertical-align: baseline;


### PR DESCRIPTION
Under -jd-reset.sup, "font-size" was throwing an error because it was spelled "ont-size."  So, I just updated that part.